### PR TITLE
fix(cloud): Fix __init__.py formatting and add AWSIAMScanner import

### DIFF
--- a/modules/cloud/__init__.py
+++ b/modules/cloud/__init__.py
@@ -1,1 +1,17 @@
-from .azure_scanner import AzureRBACScannerfrom .gcp_scanner import GCPIAMScannerfrom .kubernetes_scanner import KubernetesScannerfrom .container_scanner import ContainerScannerfrom .serverless_scanner import ServerlessScanner
+"""Cloud Security Scanners - Multi-Cloud Trinity (AWS, Azure, GCP)"""
+
+from .aws_iam_scanner import AWSIAMScanner
+from .azure_scanner import AzureRBACScanner
+from .gcp_scanner import GCPIAMScanner
+from .kubernetes_scanner import KubernetesScanner
+from .container_scanner import ContainerScanner
+from .serverless_scanner import ServerlessScanner
+
+__all__ = [
+    'AWSIAMScanner',
+    'AzureRBACScanner',
+    'GCPIAMScanner',
+    'KubernetesScanner',
+    'ContainerScanner',
+    'ServerlessScanner',
+]


### PR DESCRIPTION
## Summary

Fixes critical formatting issue in `modules/cloud/__init__.py` that prevented proper imports of the Multi-Cloud Trinity scanners.

## Changes

- **Fixed broken formatting**: Added missing newlines between imports
- **Added missing AWSIAMScanner import**: Was exported in file but not imported
- **Added `__all__` list**: Clean namespace exports

## Before (Broken)
```python
from .azure_scanner import AzureRBACScannerfrom .gcp_scanner import GCPIAMScannerfrom .kubernetes_scanner import...
```

## After (Fixed)
```python
from .aws_iam_scanner import AWSIAMScanner
from .azure_scanner import AzureRBACScanner
from .gcp_scanner import GCPIAMScanner
...
```

## Impact

- ✅ AWS IAM Scanner now importable
- ✅ All cloud scanners properly exported
- ✅ Clean namespace with `__all__`

## Testing

```python
from modules.cloud import AWSIAMScanner, AzureRBACScanner, GCPIAMScanner
# All imports work correctly now
```