### PR TITLE
fix: exact patched versions for Dependabot alerts #134, #136, #137, #138, #149, #150

### DIFF
--- a/poc/backend/requirements.txt
+++ b/poc/backend/requirements.txt
@@ -5,7 +5,7 @@
 # FastAPI Core (Pinned for stability)
 fastapi==0.109.2
 uvicorn[standard]==0.27.1
-python-multipart==0.0.20  # SECURITY FIX: CVE-2026-24486, CVE-2024-53981, CVE-2024-24762
+python-multipart==0.0.22  # SECURITY FIX: CVE-2026-24486, CVE-2024-53981, CVE-2024-24762, CVE-2025-XXXX
 
 # Database (Pinned)
 sqlalchemy==2.0.25
@@ -34,13 +34,13 @@ aiohttp==3.13.6  # SECURITY FIX: CVE-2025 family
 websockets==12.0
 
 # Security
-cryptography==44.0.3  # SECURITY FIX: CVE-2024-12356, CVE-2026-26007 (SECT curves subgroup attack)
+cryptography==46.0.5  # SECURITY FIX: CVE-2024-12356, CVE-2026-26007, CVE-2024-12797 (SECT curves)
 
 # Monitoring
 prometheus-client==0.19.0
 structlog==24.1.0
 
 # Report Generation
-weasyprint==65.1  # SECURITY FIX: SSRF Protection Bypass via HTTP Redirect (FIXED)
+weasyprint==68.0  # SECURITY FIX: SSRF Protection Bypass via HTTP Redirect (FIXED)
 jinja2==3.1.7  # SECURITY FIX: CVE-2025-27516, CVE-2024-56201 (sandbox breakout FIXED)
-markdown==3.8  # SECURITY FIX: Uncaught Exception (FIXED)
+markdown==3.8.1  # SECURITY FIX: Uncaught Exception (FIXED)

--- a/requirements-deprecated/requirements-windows.txt
+++ b/requirements-deprecated/requirements-windows.txt
@@ -13,8 +13,8 @@ alembic==1.13.1
 
 # LangChain & AI
 langchain==0.3.0
-langchain-core==0.3.84  # SECURITY FIX: CVE-2025-XXXX, SSRF via image_url (FIXED)
-langgraph==0.2.76  # SECURITY FIX: unsafe msgpack deserialization (FIXED)
+langchain-core==1.2.11  # SECURITY FIX: CVE-2025-XXXX, SSRF via image_url (FIXED)
+langgraph==1.0.10  # SECURITY FIX: unsafe msgpack deserialization (FIXED)
 openai==1.8.0
 
 # WebSocket
@@ -41,7 +41,7 @@ typer==0.9.0
 rich==13.7.0
 
 # Security
-cryptography>=44.0.1  # SECURITY FIX: CVE-2024-26130, CVE-2024-41985, CVE-2024-25185, CVE-2024-12797
+cryptography>=46.0.5  # SECURITY FIX: CVE-2024-26130, CVE-2024-41985, CVE-2024-25185, CVE-2024-12797, CVE-2024-12356, CVE-2026-26007
 
 # Testing
 pytest==7.4.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,7 +24,7 @@ netaddr>=0.9.0
 fastapi>=0.116.2  # SECURITY: Latest stable with security fixes
 starlette>=0.49.1  # SECURITY FIX: CVE-2025-62727 family
 uvicorn[standard]>=0.34.0
-python-multipart>=0.0.20  # SECURITY FIX: CVE-2026-24486, CVE-2025-41422 (Arbitrary File Write FIXED)
+python-multipart>=0.0.22  # SECURITY FIX: CVE-2026-24486, CVE-2025-41422, CVE-2025-XXXX (Arbitrary File Write FIXED)
 python-jose[cryptography]>=3.4.0  # SECURITY FIX: CVE-2024-33663
 jinja2>=3.1.7  # SECURITY FIX: CVE-2025-27516, CVE-2024-56201 (sandbox breakout FIXED)
 
@@ -50,7 +50,7 @@ textual>=0.41.0
 # ============================================================================
 # Security and Cryptography
 # ============================================================================
-cryptography>=44.0.3  # SECURITY FIX: CVE-2024-12797, CVE-2024-12356 (SECT curves subgroup attack)
+cryptography>=46.0.5  # SECURITY FIX: CVE-2024-12797, CVE-2024-12356, CVE-2026-26007 (SECT curves subgroup attack FIXED)
 PyJWT>=2.11.0  # SECURITY FIX: CVE-2025-45768, CVE-2024-33663
 passlib[bcrypt]>=1.7.4
 bcrypt>=4.0.0,<5.0.0  # Required for passlib
@@ -88,7 +88,7 @@ msgpack>=1.0.5
 # ============================================================================
 # PDF Generation (Security Fixes)
 # ============================================================================
-weasyprint>=65.1  # SECURITY FIX: SSRF Protection Bypass via HTTP Redirect (FIXED)
+weasyprint>=68.0  # SECURITY FIX: SSRF Protection Bypass via HTTP Redirect (FIXED)
 pydyf>=0.11.0  # SECURITY: Transitive dependency for weasyprint
 
 # ============================================================================


### PR DESCRIPTION
Updates all packages to exact versions required by GitHub Security Advisory database.