### PR TITLE
fix: Auto-update HTML report in coverage-live

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -99,6 +99,7 @@ clean:
 coverage-live:
 	@echo "🔄 Aktualisiere Coverage-Report..."
 	@coverage run -m pytest tests/test_working_final.py -q --tb=no 2>/dev/null || true
+	@coverage html -d htmlcov >/dev/null 2>&1 || true
 	@clear
 	@echo "╔════════════════════════════════════════════════╗"
 	@echo "║         📊 LIVE COVERAGE REPORT                ║"
@@ -110,10 +111,13 @@ coverage-live:
 	printf "║  Coverage: %5.2f%%                              ║\n" "$$COVERAGE"
 	@echo "╚════════════════════════════════════════════════╝"
 	@echo ""
-	@echo "Tipps:"
-	@echo "  make coverage-html  - HTML Report generieren"
-	@echo "  make coverage-xml   - XML für VS Code"
-	@coverage report -m 2>/dev/null | tail -5
+	@echo "📁 HTML Report: htmlcov/index.html (aktualisiert)"
+	@echo "💡 Weitere Befehle:"
+	@echo "   make coverage-html  - Nur HTML generieren"
+	@echo "   make coverage-xml   - XML für VS Code"
+	@echo "   make open-coverage  - Im Browser öffnen"
+	@echo ""
+	@coverage report -m 2>/dev/null | tail -3
 
 # Quick check - nur Prozentzahl
 coverage-now:


### PR DESCRIPTION
Makefile now auto-updates HTML report when running coverage-live