### PR TITLE
🔧 Polish: Fix Snyk version pinning and duplicate workflow name

### DIFF
--- a/.github/workflows/codecov-coverage.yml
+++ b/.github/workflows/codecov-coverage.yml
@@ -1,4 +1,4 @@
-name: Codecov Coverage
+name: Codecov Coverage Report
 
 on:
   push:

--- a/.github/workflows/snyk-security.yml
+++ b/.github/workflows/snyk-security.yml
@@ -36,7 +36,7 @@ jobs:
           pip install -r requirements.txt 2>/dev/null || pip install -e . 2>/dev/null || echo "No requirements.txt"
 
       - name: Run Snyk to check for vulnerabilities
-        uses: snyk/actions/python@master
+        uses: snyk/actions/python@0.4.0  # Pinned for security
         continue-on-error: true
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}


### PR DESCRIPTION
## Changes
- **snyk-security.yml**: Pin  to  for supply chain security
- **codecov-coverage.yml**: Rename to  to avoid duplicate workflow names

## Security
Prevents potential supply chain attacks by using pinned action versions.