### PR TITLE
🐛 CRITICAL: Fix infinite workflow loop

### DIFF
--- a/.github/workflows/auto-fix-repository.yml
+++ b/.github/workflows/auto-fix-repository.yml
@@ -185,7 +185,7 @@ jobs:
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
           git add -A
-          git commit -m "chore: Auto-fix whitespace and formatting issues [skip ci]"
+          git commit -m "[skip ci] chore: Auto-fix whitespace and formatting issues [skip ci]"
           git push
 
   security-patches:

--- a/.github/workflows/auto-repo-maintenance.yml
+++ b/.github/workflows/auto-repo-maintenance.yml
@@ -474,7 +474,7 @@ jobs:
           if git diff --staged --quiet; then
             echo "No changes to commit"
           else
-            git commit -m "chore: Update status card [automated]"
+            git commit -m "[skip ci] chore: Update status card [automated]"
             git push origin main
           fi
 

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -298,7 +298,7 @@ jobs:
             git config user.name 'GitHub Actions'
             git config user.email 'actions@github.com'
             git add ../README.md
-            git diff --staged --quiet || git commit -m "docs: update benchmark results [skip ci]"
+            git diff --staged --quiet || git commit -m "[skip ci] docs: update benchmark results [skip ci]"
             git push || echo "No changes to push"
           fi
           echo "::endgroup::"

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -46,7 +46,7 @@ jobs:
 
           git add CHANGELOG.md
 
-          git diff --quiet && git diff --staged --quiet || git commit -m "Update CHANGELOG.md
+          git diff --quiet && git diff --staged --quiet || git commit -m "[skip ci] Update CHANGELOG.md
           for ${{ github.ref_name }}"
 
           git push || true

--- a/.github/workflows/coverage-check.yml
+++ b/.github/workflows/coverage-check.yml
@@ -306,5 +306,5 @@ jobs:
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
           git add docs/badges/coverage.svg
-          git diff --staged --quiet || git commit -m "docs: update coverage badge [skip ci]"
+          git diff --staged --quiet || git commit -m "[skip ci] docs: update coverage badge [skip ci]"
           git push


### PR DESCRIPTION
## 🚨 CRITICAL BUG\n\nMultiple workflows were creating an **infinite loop**:\n1. Workflow runs → commits changes → pushes to main\n2. Push triggers more workflows → they commit → push\n3. Infinite cycle flooding the queue\n\n## 🔧 FIX\nAdded [skip ci] to git commit messages in:\n- auto-repo-maintenance.yml\n- auto-fix-repository.yml\n- benchmarks.yml\n- changelog.yml\n- coverage-check.yml\n\n## ✅ RESULT\nWorkflows that auto-commit will no longer trigger CI,\nbreaking the infinite loop.