### PR TITLE
🐛 Fix: Add [skip ci] to coverage-live-badge

### DIFF
--- a/.github/workflows/coverage-live-badge.yml
+++ b/.github/workflows/coverage-live-badge.yml
@@ -52,5 +52,5 @@ jobs:
           git config user.name "GitHub Actions"
           git config user.email "actions@github.com"
           git add README.md || true
-          git diff --quiet && git diff --staged --quiet || git commit -m "docs: Update coverage badge to ${COVERAGE}%"
+          git diff --quiet && git diff --staged --quiet || git commit -m "[skip ci] docs: Update coverage badge to ${COVERAGE}%"
           git push || true


### PR DESCRIPTION
Prevent infinite loop from coverage-live-badge workflow.